### PR TITLE
Fixed adminlist.json not generating if it doesn't exist

### DIFF
--- a/ext/admin.py
+++ b/ext/admin.py
@@ -38,7 +38,7 @@ class Admin:
             return data
             self.logger.info('Json successfully loaded.')
         except FileNotFoundError:
-            return {}
+            return {'admins' : []}
     
     def savejson(self, data, jsonname):
         try:


### PR DESCRIPTION
- return{}
+ return{'admins' : []}